### PR TITLE
Rename balance to "Undelegated CCS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ getCCSHolders(sdk)
   });
 ```
 
-### Get the stake token balance of a stakeholder
+### Get the quantity of undelegated stake token of a stakeholder
 
 ```js
 const sdk = ...
-const { getCCSBalance } = require("codechain-stakeholder-sdk");
+const { getUndelegatedCCS } = require("codechain-stakeholder-sdk");
 
-getCCSBalance(sdk, "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd")
+getUndelegatedCCS(sdk, "tccq9h7vnl68frvqapzv3tujrxtxtwqdnxw6yamrrgd")
   .then(balance => {
     // balance: U64
     ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const RLP = require("rlp");
 const HANDLER_ID = 2;
 const TRANSFER_CCS_ACTION_ID = 1;
 
-export const getCCSBalance = async (
+export const getUndelegatedCCS = async (
     sdk: SDK,
     address: PlatformAddress | string,
     blockNumber?: number


### PR DESCRIPTION
@kseo requested to change the name "Balance" into "Undelegated CCS" in order to give "Undelegated CCS + Delegated CCS" a name "Balance". 