### PR TITLE
Strip ansi escape codes from metadata

### DIFF
--- a/ccstake/package.json
+++ b/ccstake/package.json
@@ -29,11 +29,12 @@
     "CodeChain"
   ],
   "dependencies": {
+    "cli-table3": "^0.5.1",
     "codechain-sdk": "^2.0.0-alpha.2",
     "codechain-stakeholder-sdk": "^2.0.0-alpha.3",
-    "cli-table3": "^0.5.1",
     "prompt-password": "^1.2.0",
     "rlp": "^2.2.2",
+    "strip-ansi": "^5.2.0",
     "yargs": "^13.2.2"
   },
   "devDependencies": {

--- a/ccstake/src/cmds/validators.ts
+++ b/ccstake/src/cmds/validators.ts
@@ -1,13 +1,14 @@
 import { PlatformAddress } from "codechain-sdk/lib/core/classes";
 import {
+    Candidate,
     getBanned,
     getCandidates,
     getJailed,
     getTermMetadata,
     getValidators,
-    Validator,
-    Candidate
+    Validator
 } from "codechain-stakeholder-sdk";
+import stripAnsi from "strip-ansi";
 import * as yargs from "yargs";
 
 import { GlobalParams } from "..";
@@ -124,7 +125,7 @@ export const module: yargs.CommandModule<GlobalParams, GlobalParams> = {
                     delegation.toLocaleString(),
                     deposit.toLocaleString(),
                     nominationEndsAt.toString(),
-                    metadata.toString()
+                    stripAnsi(metadata.toString())
                 ]);
             }
             console.log(table.toString());


### PR DESCRIPTION
Fix https://github.com/CodeChain-io/codechain-stakeholder-sdk-js/issues/34